### PR TITLE
Rework: 'Edit Time Entry' Route

### DIFF
--- a/src/lib/components/forms/EditTimeEntryForm.svelte
+++ b/src/lib/components/forms/EditTimeEntryForm.svelte
@@ -38,6 +38,18 @@
     <Form.Item class="flex flex-col">
       <Form.Label>Notes</Form.Label>
       <Form.Textarea class="resize-y" />
+      <Form.Description>
+        Markdown syntax is supported. Click
+        <a
+          href="https://www.markdownguide.org/cheat-sheet/"
+          target="_blank"
+          rel="noreferrer"
+          class="underline hover:text-muted-foreground/80"
+        >
+          here
+        </a>
+        for more info.
+      </Form.Description>
       <Form.Validation />
     </Form.Item>
   </Form.Field>

--- a/src/routes/(app)/previous/[id]/edit/+page.svelte
+++ b/src/routes/(app)/previous/[id]/edit/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import EditTimeEntryForm from '$lib/components/forms/EditTimeEntryForm.svelte';
   import { addToast } from '$lib/components/ui/Toaster.svelte';
+  import { Button } from '$lib/components/ui/button';
   import { editTimeEntrySchema, type EditTimeEntrySchema } from '$lib/schemas/index.js';
   import { convertSelectData } from '$lib/utils.js';
   import type { FormOptions } from 'formsnap';
+  import { Undo2 } from 'lucide-svelte';
+  import moment from 'moment';
 
   export let data;
 
@@ -30,7 +33,19 @@
 </script>
 
 <main class="container mx-auto">
-  <h2 class="heading-1">Edit - {data.timeEntry?.name}</h2>
+  <div class="flex gap-3">
+    <Button variant="ghost" size="icon" href="/previous">
+      <Undo2 />
+    </Button>
+    <div>
+      <h2 class="heading-1 mb-2">Edit - {data.timeEntry?.name}</h2>
+      <p class="mb-4 text-sm text-muted-foreground">
+        Start Time: {moment(data.timeEntry?.start_time).format('MM/DD/YY hh:mma')} • End Time: {moment(
+          data.timeEntry?.end_time
+        ).format('MM/DD/YY hh:mma')}
+      </p>
+    </div>
+  </div>
   {#if data.form}
     <EditTimeEntryForm
       form={data.form}


### PR DESCRIPTION
### Description of Changes

- Add a button to allow a user to navigate back to the `/previous` route when within the edit page of a time entry
- Add help description to notes field regarding markdown syntax

#### Other Notes

- Resolves #15 