### PR TITLE
Fix: `TimeTable` Filtering and `Shared` Route

### DIFF
--- a/src/lib/components/ui/TimeTable.svelte
+++ b/src/lib/components/ui/TimeTable.svelte
@@ -32,6 +32,24 @@
     })
   });
 
+  const excludeFromFilter = {
+    plugins: {
+      filter: {
+        exclude: true
+      }
+    }
+  };
+
+  const convertFilterValue = {
+    plugins: {
+      filter: {
+        getFilterValue: (result: any) => {
+          return humanize(result);
+        }
+      }
+    }
+  };
+
   const columns = table.createColumns([
     table.column({
       accessor: 'name',
@@ -46,24 +64,22 @@
       header: 'Start Time',
       cell: ({ value }) => {
         return humanize(value);
-      }
+      },
+      ...convertFilterValue
     }),
     table.column({
       accessor: 'end_time',
       header: 'End Time',
       cell: ({ value }) => {
         return humanize(value);
-      }
+      },
+      ...convertFilterValue
     }),
     table.column({
       accessor: 'elapsed_time',
       header: 'Total Time',
       cell: ({ value }) => humanize(value),
-      plugins: {
-        filter: {
-          exclude: true
-        }
-      }
+      ...excludeFromFilter
     }),
     table.column({
       accessor: ({ expand }) => expand?.shared_users,
@@ -73,11 +89,7 @@
           users: value
         });
       },
-      plugins: {
-        filter: {
-          exclude: true
-        }
-      }
+      ...excludeFromFilter
     }),
     table.column({
       accessor: (item) => item,
@@ -97,11 +109,7 @@
           deleteTimeForm
         });
       },
-      plugins: {
-        filter: {
-          exclude: true
-        }
-      }
+      ...excludeFromFilter
     })
   ]);
 

--- a/src/lib/components/ui/TimeTable.svelte
+++ b/src/lib/components/ui/TimeTable.svelte
@@ -20,6 +20,7 @@
     | TimeEntriesResponse<{
         customer: CustomersResponse;
         shared_users: UsersResponse[];
+        author: UsersResponse;
       }>[]
     | RecordModel[];
   export let deleteTimeForm: SuperValidated<DeleteTimeEntrySchema> | undefined = undefined;

--- a/src/routes/(app)/shared/+page.server.ts
+++ b/src/routes/(app)/shared/+page.server.ts
@@ -2,7 +2,7 @@ export async function load({ locals }) {
   const sharedTimeEntries = locals.pb?.collection('time_entries').getFullList({
     filter: `shared_users ?~ "${locals.user.id}"`,
     sort: '-start_time',
-    expand: 'customer,shared_users'
+    expand: 'customer,shared_users,author'
   });
 
   return {


### PR DESCRIPTION
### Description of Changes

- Create helper objects with filter plugin options as many columns need the same type of plugin options
    - Create `excludeFromFilter` which will exclude column from filtering plugin
    - Create `convertFilterValue` which will convert the value of the column cell to the humanized date format to allow for proper filtering of the `start_time` and `end_time` column
- Set helper objects within proper table columns
- Update typing on `TimeTable` `data` prop
- Update `shared` route load function to support additional expanded field per changes made by #16 

#### Other Notes

- Resolves #26 
- Resolves #30 